### PR TITLE
migration script for launchkeys was missing

### DIFF
--- a/migrations/010-add-launchkey-to-config.js
+++ b/migrations/010-add-launchkey-to-config.js
@@ -1,0 +1,9 @@
+var migrations  = require('./migrations');
+
+exports.up = function(next){
+  migrations.runBlock('010-addLaunchKeyConfig', next);
+};
+
+exports.down = function(next) {
+  next();
+};

--- a/migrations/migrations.sql
+++ b/migrations/migrations.sql
@@ -225,3 +225,22 @@ INSERT INTO config (configId, configName, data, roles)
 SELECT configId, configName, data, roles FROM configTemp;
 
 DROP TABLE configtemp;
+
+-- 010-addLaunchKeyConfig
+ALTER TABLE config RENAME TO configtemp;
+
+CREATE TABLE config (
+  configId INTEGER PRIMARY KEY AUTOINCREMENT,
+  configName NVARCHAR(255),
+  data TEXT,
+  launchKey TEXT,
+  roles TEXT,
+  envId INTEGER,
+  FOREIGN KEY (envId) REFERENCES env(envId)
+);
+
+INSERT INTO config (configId, configName, data, roles, envId)
+SELECT configId, configName, data, roles, envId
+FROM configtemp;
+
+DROP TABLE configtemp;


### PR DESCRIPTION
Somehow the sqlite migration scripts were not added to my PR for adding launch keys.