### PR TITLE
Logs should be stored in the database

### DIFF
--- a/migrations/012-add-job-table.js
+++ b/migrations/012-add-job-table.js
@@ -1,0 +1,9 @@
+var migrations  = require('./migrations');
+
+exports.up = function(next){
+  migrations.runBlock('012-addJobTable', next);
+};
+
+exports.down = function(next) {
+  next();
+};

--- a/migrations/013-clear-deployed-jobs.js
+++ b/migrations/013-clear-deployed-jobs.js
@@ -1,0 +1,9 @@
+var migrations  = require('./migrations');
+
+exports.up = function(next){
+  migrations.runBlock('013-clearDeployedJobs', next);
+};
+
+exports.down = function(next) {
+  next();
+};

--- a/migrations/migrations.sql
+++ b/migrations/migrations.sql
@@ -271,3 +271,12 @@ SELECT envId, envName, envDesc, remoteType, remoteId, status, config, deployedBy
 
 DROP table envtemp;
 
+-- 012-addJobTable
+CREATE TABLE jobs (
+  jobId INTEGER NOT NULL,
+  log TEXT
+)
+
+-- 013-clearDeployedJobs
+UPDATE env
+SET   deployedJobId = NULL

--- a/src/client/app/environments/list-item.html
+++ b/src/client/app/environments/list-item.html
@@ -61,7 +61,7 @@
       </div>
     </div>
 
-    <div class="row" ng-show="vm.environment.deployedJobId && false">
+    <div class="row" ng-show="vm.environment.deployedJobId">
       <div class="col-md-3"><strong>Last Job:</strong></div>
       <div class="col-md-9"><a href='/app/jobs/{{vm.environment.deployedJobId}}'>Job #{{vm.environment.deployedJobId}}</a></div> 
     </div>

--- a/src/client/app/environments/redeploy/dialog.directive.js
+++ b/src/client/app/environments/redeploy/dialog.directive.js
@@ -408,7 +408,7 @@
             filterLevelItemRoot.isActive = true;
             filterLevelItemRoot.selectable = false;
             filterLevelItemRoot.isSelected = true;
-            if (rootLevelFeatureItem.KeyType.toUpperCase() === "DEVELOPMENT") {
+            if (rootLevelFeatureItem.KeyType.toUpperCase() === 'DEVELOPMENT') {
                 filterLevelItemRoot.children.forEach(function (child) {
                     child.selectable = false;
                 });
@@ -478,12 +478,12 @@
             enableExpandAll: false,
             showTreeExpandNoChildren: true,
             treeRowHeaderAlwaysVisible: false,
-            headerClass: "ui-grid-noborder",
+            headerClass: 'ui-grid-noborder',
             width: 200,
             columnDefs: [
-            { name: 'isActive', displayName: 'Active', type: 'boolean', cellTemplate: '<div ng-hide=row.entity.hideCheck><input type="checkbox" ng-model="row.entity.isActive"  ng-click="ui-grid.appScope.click(row.entity.name, row.entity.isActive)" ng-disabled=!row.entity.selectable></div>', enableColumnMenu: false, width:"25" , cellClass: "ui-grid"},
-            { name: 'name',enableHiding: false, enableColumnMenu: false, visible: true, pinnedLeft:true, width:"25%", cellClass: "ui-grid",  },
-            { name: 'description',  enableHiding: false, enableColumnMenu: false, visible: true, width:"*", cellClass: "ui-grid" }
+            { name: 'isActive', displayName: 'Active', type: 'boolean', cellTemplate: '<div ng-hide=row.entity.hideCheck><input type="checkbox" ng-model="row.entity.isActive"  ng-click="ui-grid.appScope.click(row.entity.name, row.entity.isActive)" ng-disabled=!row.entity.selectable></div>', enableColumnMenu: false, width:'25' , cellClass: 'ui-grid'},
+            { name: 'name',enableHiding: false, enableColumnMenu: false, visible: true, pinnedLeft:true, width:'25%', cellClass: 'ui-grid',  },
+            { name: 'description',  enableHiding: false, enableColumnMenu: false, visible: true, width:'*', cellClass: 'ui-grid' }
         ]};
     }
   

--- a/src/server/controllers/jobs.js
+++ b/src/server/controllers/jobs.js
@@ -4,15 +4,13 @@ var debug       = require('debug')('deployer-projects')
   , jobrunner  = require('../jobrunner');
 
 
-
-
 exports.list = function list(req, res) {
   res.send(jobrunner.getJobs());
 };
 
-
-
 exports.get = function get(req, res) {
   var jobId = req.param('jobId');
-  res.send(jobrunner.getJob(jobId));
+  jobrunner.getJob(jobId, function(err, data){
+    res.send(data);
+  });
 };

--- a/src/server/job.js
+++ b/src/server/job.js
@@ -76,6 +76,11 @@ Job.prototype.start = function start() {
       job.error = err;
       env.status = 'failed';
       return envService.update(env);
+    })
+
+    // all done
+    .fin(function(){
+      return envService.log(job);
     });
 
   });

--- a/src/server/mappers/jobs-mapper.js
+++ b/src/server/mappers/jobs-mapper.js
@@ -1,0 +1,70 @@
+var util          = require('util')
+  , Q             = require('q')
+  , statements    = require('statements')
+  , SqliteMapper  = require('hops-sqlite')
+  , Job           = require('../models/job')
+  , jobSql        = statements.read(__dirname + '/jobs.sql')
+  ;
+
+
+
+function JobMapper() {
+  SqliteMapper.apply(this, arguments);
+}
+util.inherits(JobMapper, SqliteMapper);
+
+module.exports = JobMapper;
+
+JobMapper.prototype.parseArray = function parseArray(array) {
+  return array.map(this.parse);
+};
+
+JobMapper.prototype.insert = function insert(job, next) {
+  var sql = jobSql.insert
+    , params = {};
+
+  params = {
+    $jobId: job.jobId,
+    $log: job.log
+  };
+
+  return this.run(sql, params, next);
+};
+
+JobMapper.prototype.update = function update(job, next) {
+  var sql = jobSql.update
+    , params = {};
+
+  params = {
+    $jobId: job.jobId,
+    $log: job.log
+  };
+
+  return this.run(sql, params, next);
+};
+
+JobMapper.prototype.getById = function getById(jobId, next) {
+  var sql = jobSql.getById
+    , params = {
+      $jobId: jobId
+    };
+
+  return this
+    .get(sql, params)
+    .then(function(row) {
+      return row;
+    })
+    .nodeify(next);
+};
+
+JobMapper.prototype.maxJobId = function(next){
+  var sql = jobSql.maxid
+    , params = {};
+
+  return this
+    .get(sql, params)
+    .then(function(row) {
+      return row.jobId;
+    })
+    .nodeify(next);
+};

--- a/src/server/mappers/jobs.sql
+++ b/src/server/mappers/jobs.sql
@@ -1,0 +1,17 @@
+-- insert
+insert into jobs (jobId, log)
+values ($jobId, $log);
+
+-- update
+update jobs
+set log = $log
+where jobId = $jobId;
+
+-- maxid
+select max(jobid) as jobId
+from jobs
+
+-- getById
+select *
+from   jobs
+where  jobId = $jobId

--- a/src/server/models/job.js
+++ b/src/server/models/job.js
@@ -1,0 +1,17 @@
+var Model       = require('hops-model')
+  , schema
+  , Job
+  ;
+
+/* eslint-disable */
+schema = {
+  "properties": [
+    { "name": "jobId" },
+    { "name": "log" }
+  ]
+};
+/* eslint-enable */
+
+
+Job = Model.extend(schema);
+module.exports = Job;

--- a/src/server/services/env-service.js
+++ b/src/server/services/env-service.js
@@ -2,6 +2,7 @@ var debug           = require('debug')('deployer-envservice')
   , Q               = require('q')
   , Skytap          = require('node-skytap')
   , EnvMapper       = require('../mappers/env-mapper')
+  , JobMapper       = require('../mappers/jobs-mapper') 
   , MachineMapper   = require('../mappers/machine-mapper')
   , Env             = require('../models/env')
   , config          = require('../../../config')
@@ -9,6 +10,7 @@ var debug           = require('debug')('deployer-envservice')
   , machineService  = require('./machine-service')
   , skytap          = Skytap.init(config.skytap)
   , envMapper       = new EnvMapper(dbPath)
+  , jobMapper       = new JobMapper(dbPath)
   , machineMapper   = new MachineMapper(dbPath)
   , findById
   ;
@@ -105,6 +107,15 @@ exports.update = function update(data, next) {
     .then(joinEnvMachines)
     .then(joinEnvSkytap)
     .nodeify(next);
+};
+
+exports.log = function log(job, next) {
+  var data = {
+    jobId: job.id,
+    log: JSON.stringify(job)
+  };
+
+  return jobMapper.insert(data).nodeify(next);
 };
 
 exports.remove = function remove(envId, next) {

--- a/src/server/services/launchkey-service.js
+++ b/src/server/services/launchkey-service.js
@@ -117,7 +117,7 @@ exports.getLitKeys = function getLitKeys(data, next) {
                         Object.getOwnPropertyNames(config.data).some(function (val, idx, array) {
                             configKeyParts = val.split('|');
                             if (configKeyParts && configKeyParts.length == 2) {
-                                if (configKeyParts[1] === "IS_SQLSERVER_DATABASE") {
+                                if (configKeyParts[1] === 'IS_SQLSERVER_DATABASE') {
                                     configSource = configKeyParts[0];
                                     return true;
                                 }

--- a/src/server/tasks/task.js
+++ b/src/server/tasks/task.js
@@ -47,10 +47,6 @@ util.inherits(Task, events.EventEmitter);
 module.exports = Task;
 
 
-
-
-
-
 Task.prototype.start = function start(scope) {
   this.started = new Date();
   this.status = 'Running';


### PR DESCRIPTION
- jobs are stored in memory still
- as a job completes, it is stored into the database
- upon server restart we get the last id from the table and allow the application to manage creating the ids
- if the server has restarted and the job is no longer in memory, we grab the log from the database and load it into memory for future use
- previous deployed ids are wiped as those numbers didn't really mean anything and could no be logged to a job. there were also redundant id's since a restart previously meant starting back at 1
- previous job shown once again in the environment list
- whitespace and linter god appeasement