### PR TITLE
Fixes a bug with no keys

### DIFF
--- a/src/client/app/environments/redeploy/dialog.directive.js
+++ b/src/client/app/environments/redeploy/dialog.directive.js
@@ -285,7 +285,7 @@
         });
       } 
       else {
-        return;
+        filteredLaunchKeys = [];
       }
 
       return Config.sendLaunchKeys({envId: vm.tempEnv.envId, launchKeys: filteredLaunchKeys });


### PR DESCRIPTION
When there are no keys available or selected, you get a JS error,
instead of deploying it in LTS mode.