### PR TITLE
Version checking of files across ftp and smb

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "repository": "fti-technology/ringtail-deploy-web",
   "dependencies": {
     "activedirectory": "^0.7.2",
+    "async": "^2.0.0",
     "body-parser": "^1.15.0",
     "chalk": "^1.1.1",
     "cookie-parser": "^1.4.3",
@@ -28,6 +29,7 @@
     "hops-model": "^0.3.0",
     "hops-sqlite": "^0.1.0",
     "migrate": "^0.2.2",
+    "morgan": "^1.7.0",
     "nib": "^1.1.0",
     "node-skytap": "^0.7.0",
     "q": "^1.4.1",

--- a/src/client/app/environments/redeploy/dialog.directive.js
+++ b/src/client/app/environments/redeploy/dialog.directive.js
@@ -240,7 +240,7 @@
         vm.launchKeys = null;
         vm.hideLaunchKeys = true;
         getLaunchKeysForBuild();
-        var version = vm.version || "0.0.0.0"; //need to pass something even if there is nothing
+        var version = vm.version || '0.0.0.0'; //need to pass something even if there is nothing
         Browse.files({regionId: vm.regionId, branch: constructBranchPath(), version: version }, function(files) {
           vm.loadingFiles = false;
           vm.filesOk = files.length == 0 || files[0] !== 'OK';

--- a/src/client/app/environments/redeploy/dialog.directive.js
+++ b/src/client/app/environments/redeploy/dialog.directive.js
@@ -58,6 +58,7 @@
     vm.click              = onFeatureKeyCheckClick;
     vm.featureGrid        = initFeatureGrid();
     vm.taskArray          = ['3-install-many'];
+    vm.version            = null;
         
     activate();
 
@@ -70,6 +71,10 @@
       vm.selectedBranch = parseBranchPath(vm.tempEnv.deployedBranch);
 
       vm.loadingBranches = true;
+      Config.version({envId: vm.tempEnv.envId}, function(result) {
+          vm.version = result.version;
+          return;
+      });
       Browse.branches({ regionId: vm.regionId }, function(branches) {
         vm.loadingBranches = false;
         vm.branches = branches.sort(function(a, b) {
@@ -235,7 +240,8 @@
         vm.launchKeys = null;
         vm.hideLaunchKeys = true;
         getLaunchKeysForBuild();
-        Browse.files({regionId: vm.regionId, branch: constructBranchPath() }, function(files) {
+        var version = vm.version || "0.0.0.0"; //need to pass something even if there is nothing
+        Browse.files({regionId: vm.regionId, branch: constructBranchPath(), version: version }, function(files) {
           vm.loadingFiles = false;
           vm.filesOk = files.length == 0 || files[0] !== 'OK';
           if(files.length > 0) {

--- a/src/client/app/environments/redeploy/dialog.html
+++ b/src/client/app/environments/redeploy/dialog.html
@@ -19,7 +19,7 @@
       </select>
     </div>
     <div class="form-group">
-      <label>Install Build:</label>
+      <label>Install Build: <span ng-show='vm.version'>(Current: {{vm.version}})</span></label>
       <div class="list-loading" ng-show="vm.loadingBuilds">
         <img src="/assets/img/bar-loader.gif">
       </div>

--- a/src/client/app/shared/data/browse.service.js
+++ b/src/client/app/shared/data/browse.service.js
@@ -14,7 +14,7 @@
       {
         branches: { method: 'GET', url: 'api/regions/:regionId/branches', isArray: true },
         builds:   { method: 'GET', url: 'api/regions/:regionId/branches/:branch/builds', isArray: true },
-        files:    { method: 'GET', url: 'api/regions/:regionId/branches/:branch/files', isArray: true }
+        files:    { method: 'GET', url: 'api/regions/:regionId/branches/:branch/version/:version/files', isArray: true }
       }
     );      
   }

--- a/src/client/app/shared/data/config.service.js
+++ b/src/client/app/shared/data/config.service.js
@@ -17,6 +17,7 @@
           sendLaunchKeys: { method: 'PUT',  url: 'api/envs/sendLaunchKeys'},
           update   : { method: 'PUT',  url: 'api/configs/:configId' },
           litKeys: { method: 'GET',  url: 'api/envs/:envId/branches/:branch/litKeys', isArray: true },
+          version: { method: 'GET',  url: 'api/envs/:envId/version', isArray: false }          
       }
     );
   }

--- a/src/server/controllers/browse.js
+++ b/src/server/controllers/browse.js
@@ -50,26 +50,19 @@ exports.builds = function builds(req, res, next) {
 exports.files = function files(req, res, next) {
   var id      = req.params.regionId
     , branch  = req.params.branch
+    , version = req.params.version
     ;
 
   Q.fcall(function() { 
       return regionService.findById(id);
     })
     .then(function(region) {  
-      return browserFactory.fromRegion(region);
+      return browserFactory.fromRegion(region, version);
     })
     .then(function(browser) {
       return browser.files(branch);      
     })
-    .then(function(files) {
-      var manifestOk = files.indexOf('Manifest.txt') !== -1; 
-      
-      if(!manifestOk) {
-        //files = null;
-      } else {
-
-      }
-      
+    .then(function(files) {     
       res.send(files);
     })
     .fail(function(err) {

--- a/src/server/controllers/envs.js
+++ b/src/server/controllers/envs.js
@@ -27,6 +27,17 @@ exports.get = function get(req, res, next) {
     });
 };
 
+exports.version = function get(req, res, next) {
+  debug('getting environment');
+  var envId = req.params.envId;
+  envService
+    .version(envId, function(err, result) {
+      res.result  = result;
+      res.err     = err;
+      next();
+    });
+};
+
 
 exports.create = function create(req, res, next) {
   debug('creating environment');

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -11,6 +11,7 @@ var path        = require('path')
   , session     = require('express-session')
   , cookieParser = require('cookie-parser')
   , migrate     = require('migrate')
+  , logger      = require('morgan')
   , app;
 
 app = express();
@@ -50,7 +51,7 @@ app.set('trust proxy', 1);
 app.use('/assets', serveStatic(__dirname + '/../client/assets'));
 app.use('/assets/lib', serveStatic(__dirname + '/../client/assets/bower_components'));
 app.use('/app', serveStatic(__dirname + '/../client/app'));
-
+app.use(logger('dev'));
 
 // DEFAULT ROUTE
 function defaultRoute(req, res) {
@@ -116,7 +117,7 @@ app.put   ('/api/regions/:regionId', controllers.regions.update);
 app.delete('/api/regions/:regionId', controllers.regions.del);
 app.get   ('/api/regions/:regionId/branches', controllers.browse.branches);
 app.get   ('/api/regions/:regionId/branches/:branch/builds', controllers.browse.builds);
-app.get   ('/api/regions/:regionId/branches/:branch/files', controllers.browse.files);
+app.get   ('/api/regions/:regionId/branches/:branch/version/:version/files', controllers.browse.files);
 
 // API - CONFIG ROUTES
 app.post  ('/api/configs', controllers.configs.create);
@@ -140,6 +141,7 @@ app.put   ('/api/envs/:envId/pause', controllers.envs.pause);
 app.put   ('/api/envs/:envId/redeploy', controllers.envs.redeploy);
 app.put   ('/api/envs/:envId/reset', controllers.envs.reset);
 app.get   ('/api/envs/:envId/configs', controllers.configs.findByEnv);
+app.get   ('/api/envs/:envId/version', controllers.envs.version);
 app.get   ('/api/envs/:envId/branches/:branch/launchKeys', controllers.configs.launchKeys);
 app.get   ('/api/envs/:envId/branches/:branch/litKeys', controllers.configs.litKeys);
 app.put   ('/api/envs/sendLaunchKeys', controllers.configs.sendLaunchKeys);
@@ -233,6 +235,6 @@ debugapp.log = function() {
   var text = util.format.apply(this, arguments);
 
   // log to console and file
-  console.log(text);
+  // console.log(text);
   fs.appendFileSync('access.log', text + '\n');
 };

--- a/src/server/services/browser-factory.js
+++ b/src/server/services/browser-factory.js
@@ -19,7 +19,7 @@ exports.fromRegion = function(region, currentVersion) {
     , result = null
     ;
 
-  config.currentVersion = currentVersion || "99.99.99.99";
+  config.currentVersion = currentVersion || '99.99.99.99';
 
   if(config.type === 'http') {
     result = new HttpBrowser(config);

--- a/src/server/services/browser-factory.js
+++ b/src/server/services/browser-factory.js
@@ -14,10 +14,12 @@ var EmptyBrowser  = require('./browsers/empty-browser')
  * default to EmptyBrowser if it can't build the appropriate
  * browser
  */
-exports.fromRegion = function(region) {
+exports.fromRegion = function(region, currentVersion) {
   var config = region.browseConfig || {}
     , result = null
     ;
+
+  config.currentVersion = currentVersion || "99.99.99.99";
 
   if(config.type === 'http') {
     result = new HttpBrowser(config);

--- a/src/server/services/browsers/FTPOperations.csx
+++ b/src/server/services/browsers/FTPOperations.csx
@@ -242,10 +242,6 @@ private static bool AllowBranchVersion(string current, string manifest) {
             var intCurrentVal = Int32.Parse(cArray[i]);
             var intManifestVal = Int32.Parse(mArray[i]);
 
-            Console.WriteLine("-----------------------------------");
-            Console.WriteLine(intCurrentVal);
-            Console.WriteLine(intManifestVal);
-
             if(intCurrentVal == intManifestVal) {
                 continue;
             }
@@ -291,10 +287,7 @@ private static bool AllowBranchVersion(string current, string manifest) {
                 if (y.Contains(x.FileName))
                 {
                     fileExists = true;
-                    Console.WriteLine("-------------------------");
-                    Console.WriteLine(x.FileName);
-                    Console.WriteLine(x.FileSize.ToString());
-                    Console.WriteLine(y);
+
                     if (y.Contains(x.FileSize.ToString()))
                     {
                         fileSizeMatch = true;
@@ -523,8 +516,7 @@ private static bool AllowBranchVersion(string current, string manifest) {
                     string version = "99.99.99.9999";
 
                     bool success = long.TryParse(splitLine[1], out length);
-                    Console.WriteLine("Length");
-                    Console.WriteLine(splitLine.Length);
+
                     if(splitLine.Length > 2){
                         version = splitLine[2];
                     }

--- a/src/server/services/browsers/FTPOperations.csx
+++ b/src/server/services/browsers/FTPOperations.csx
@@ -58,6 +58,13 @@ public class Startup
     }
 }
 
+public enum ReturnValues
+{
+    OK = 1,
+    VersionMismatch = 2,
+    FileSizeMismatch = 3
+}
+
 // Utility class just to keep arguments clean
 public class Options
 {
@@ -104,7 +111,6 @@ public static class Helper
             List<string> remoteList = ValidateRemoteLocation(input, WebRequestMethods.Ftp.ListDirectoryDetails);
             var jsonSerialiser = new JavaScriptSerializer();
             var result = jsonSerialiser.Serialize(remoteList);
-            //Console.WriteLine(result);
             return result;
         }
         catch(Exception ex)
@@ -181,7 +187,8 @@ public static class Helper
                             if (request != null)
                             {
                                 var tmpResult = new List<string>();
-                                okOverall = VerifyManifest(request, result, out tmpResult);
+                                var verifyResult = VerifyManifest(request, result, input, out tmpResult);
+
                                 result = tmpResult;
 
                                 if(result.Count == 0)
@@ -193,6 +200,7 @@ public static class Helper
                         }
                         catch(Exception ex)
                         {
+                            Console.WriteLine(ex.ToString());
                             result = new List<string>();
                             result.Add("There is no manifest file in this location.");
                             okOverall = false;
@@ -221,7 +229,39 @@ public static class Helper
         return result;
     }
 
-    private static bool VerifyManifest(FtpWebRequest request, List<string> listing, out List<string> validationResult)
+private static bool AllowBranchVersion(string current, string manifest) {
+        var cArray = current.Split('.');
+        var mArray = manifest.Split('.');
+
+        //mismatch, allow it
+        if(cArray.Length != mArray.Length) {
+            return true;
+        }
+
+        for(var i = 0; i < cArray.Length; i++ ){
+            var intCurrentVal = Int32.Parse(cArray[i]);
+            var intManifestVal = Int32.Parse(mArray[i]);
+
+            Console.WriteLine("-----------------------------------");
+            Console.WriteLine(intCurrentVal);
+            Console.WriteLine(intManifestVal);
+
+            if(intCurrentVal == intManifestVal) {
+                continue;
+            }
+
+            else if(intCurrentVal > intManifestVal) {
+                return false;
+            }
+
+            return true;
+        }
+
+        //i don't know what happened, but allow it
+        return true;
+    }
+
+    private static ReturnValues VerifyManifest(FtpWebRequest request, List<string> listing, dynamic input, out List<string> validationResult)
     {
         var okOverall = false;
         var manifestContents = GetManifestFileContents(request);
@@ -233,6 +273,17 @@ public static class Helper
             {
                 continue;
             }
+            
+            if(input.currentVersion != null && input.currentVersion != "0.0.0.0"){
+                if(x.FileName.IndexOf("Ringtail_Main Ringtail8") >= 0){
+                    var allowIt = AllowBranchVersion(input.currentVersion, x.Version);
+                    if(!allowIt) { 
+                        validationResult.Add("Ringtail version too old.");
+                        return ReturnValues.VersionMismatch;
+                    }
+                }
+            }
+
             bool fileExists = false;
             bool fileSizeMatch = false;
             foreach (var y in listing)
@@ -240,6 +291,10 @@ public static class Helper
                 if (y.Contains(x.FileName))
                 {
                     fileExists = true;
+                    Console.WriteLine("-------------------------");
+                    Console.WriteLine(x.FileName);
+                    Console.WriteLine(x.FileSize.ToString());
+                    Console.WriteLine(y);
                     if (y.Contains(x.FileSize.ToString()))
                     {
                         fileSizeMatch = true;
@@ -268,7 +323,11 @@ public static class Helper
             okOverall = okOverall ? fileExists && fileSizeMatch : false;
         }
 
-        return okOverall;
+        if(okOverall) {
+            return ReturnValues.OK;
+        }
+
+        return ReturnValues.FileSizeMismatch;
     }
 
     public static FtpWebRequest FtpConnectionRequest(Options options)
@@ -457,11 +516,21 @@ public static class Helper
                 while (!string.IsNullOrEmpty(_line))
                 {
                     var line = _line.Replace("\"", "");
+                    var splitLine = line.Split(':');
                     FileItem fi = new FileItem();
-                    fi.FileName = line.Split(':')[0];
+                    fi.FileName = splitLine[0];
                     long length = 0;
+                    string version = "99.99.99.9999";
 
-                    bool success = long.TryParse(line.Split(':')[1], out length);
+                    bool success = long.TryParse(splitLine[1], out length);
+                    Console.WriteLine("Length");
+                    Console.WriteLine(splitLine.Length);
+                    if(splitLine.Length > 2){
+                        version = splitLine[2];
+                    }
+
+                    fi.Version = version;
+                    
                     if(success)
                     {
                         fi.FileSize = length;
@@ -564,11 +633,12 @@ public class FileItem
     }
 
     public string FileName { get; set; }
+    public string Version { get; set; }
     public long FileSize { get; set; }
 
 
     public override string ToString()
     {
-        return String.Format("{0} | {1}", FileName, FileSize);
+        return String.Format("{0} | {1} | {2}", FileName, FileSize, Version);
     }
 }

--- a/src/server/services/browsers/ftp-browser.js
+++ b/src/server/services/browsers/ftp-browser.js
@@ -110,11 +110,9 @@ FTPBrowser.prototype.files = function files(branch, next) {
   params.branch = this.ftpRootPath.replace(/\/$/, '') + '/' + branch;
   ftp(params, function (error, result) {
     if (error) {
-      console.log("AIRRRR");
       deferred.reject(error);
     }
     else {
-      console.log("result", result);
       deferred.resolve(result);
     }
   });

--- a/src/server/services/browsers/ftp-browser.js
+++ b/src/server/services/browsers/ftp-browser.js
@@ -32,7 +32,8 @@ FTPBrowser.prototype.branches = function branches(next) {
       ftpProxyHost: this.ftpProxyHost,
       ftpProxyPort: '',
       action: currentAction.value,
-      branch: this.ftpRootPath
+      branch: this.ftpRootPath,
+      currentVersion: this.currentVersion
    };
 
   debug('looking for branches via ftp');
@@ -66,7 +67,8 @@ FTPBrowser.prototype.builds = function builds(branch, next) {
         ftpProxyHost: this.ftpProxyHost,
         ftpProxyPort: '',
         action: currentAction.value,
-        branch: ''
+        branch: '',
+      currentVersion: this.currentVersion
       };
 
   
@@ -100,16 +102,19 @@ FTPBrowser.prototype.files = function files(branch, next) {
         ftpProxyHost: this.ftpProxyHost,
         ftpProxyPort: '',
         action: currentAction.value,
-        branch: this.ftpRootPath.replace(/\/$/, '') + '/' + branch
+        branch: this.ftpRootPath.replace(/\/$/, '') + '/' + branch,
+        currentVersion: this.currentVersion
       };
 
   branch = branch.replace('\\', '/');
   params.branch = this.ftpRootPath.replace(/\/$/, '') + '/' + branch;
   ftp(params, function (error, result) {
     if (error) {
+      console.log("AIRRRR");
       deferred.reject(error);
     }
     else {
+      console.log("result", result);
       deferred.resolve(result);
     }
   });

--- a/src/server/services/browsers/ftptest.bat
+++ b/src/server/services/browsers/ftptest.bat
@@ -1,0 +1,1 @@
+csi FTPOperations.csx

--- a/src/server/services/browsers/smb-browser.js
+++ b/src/server/services/browsers/smb-browser.js
@@ -125,6 +125,7 @@ SmbBrowser.listDirs = function listDirs(dir, next) {
  * @return {promise} resolves to an array of directory names
  */
 SmbBrowser.listFiles = function listFiles(dir, next) {
+  console.log("LISTFILES");
   var foldersOnly = function(stat, file) {
     return stat.isDirectory() ? null : file;
   },
@@ -144,6 +145,7 @@ SmbBrowser.listFiles = function listFiles(dir, next) {
  * @return {promise} resolves to an array of directory names
  */
 SmbBrowser.readContents = function readContents(file, next) {
+  console.log("READCONTENTS");
   var me = this;
   return Q
     .nfcall(fs.readFile, file, 'utf8', next)
@@ -155,15 +157,21 @@ SmbBrowser.readContents = function readContents(file, next) {
 };
 
 SmbBrowser.readManifestFile = function readManifestFile(contents) {
+  console.log("READ");
+  
   return _.map(contents.split('\n'), function(row) {
     var cleaned = row.replace(/['"]+/g, '').replace(/['\r']+/g, ''),
-      splitEntry = cleaned.split(':'),
-      obj = { name: splitEntry[0], size: splitEntry[1]};
+      splitEntry = cleaned.split(':');
+
+    var version = splitEntry[2] || "99.99.99.99"
+
+    var obj = { name: splitEntry[0], size: splitEntry[1], version: version};
     return obj;
   });
 };
 
 SmbBrowser.compareManifestToMap = function compareManifestToMap(manifestContents, onDiskMap) {
+  console.log("COMPARE");
   return _.map(manifestContents, function(item) {
     var match = _.filter(onDiskMap, function (fileInfo) {
       return fileInfo.name === item.name;
@@ -195,6 +203,7 @@ SmbBrowser.getNameSizeMap = function getNameSizeMap(dir, next) {
 };
 
 SmbBrowser.filteredListContents = function filteredListContents(cfg, next) {
+  console.log("FILTER");
   var dir = cfg.dir,
     filterFn = cfg.filterFn;
 
@@ -202,14 +211,18 @@ SmbBrowser.filteredListContents = function filteredListContents(cfg, next) {
     .nfcall(fs.readdir, dir)
     .then(function(files) {
       return Q.all(files.map(function(file) {
+        console.log("FILE", file);
+        
         var fullPath = path.join(dir, file);
         return Q.nfcall(fs.stat, fullPath).then(function(stat) {
+          console.log("STAT", stat);
           var x = filterFn(stat, file);
           return x;
         });
       }));
     })
     .then(function(dirs) {
+      console.log("DIRS", dirs)
       return dirs.filter(function(dir) { 
         return !!dir;
       });

--- a/src/server/services/browsers/smb-browser.js
+++ b/src/server/services/browsers/smb-browser.js
@@ -50,30 +50,39 @@ SmbBrowser.prototype.files = function files(branch, next) {
   var deferred = Q.defer();
 
   this.reconcileManifestWithDisk(branch, function(err, results) {
-    if(err) deferred.reject(err); 
-
     var data = [];
+    
+    if(err) {
+      if(/manifest/i.test(err)){
+        return deferred.resolve(['manifest.txt is missing']);
+      } else {
+        return deferred.reject(err);
+        
+      }
+    } 
+
+    if(!results) results = [];
 
     results.forEach(function(result){
       var item;
-      if(result.name == "Name" || result.name.trim().length == 0) {
+      if(result.name == 'Name' || result.name.trim().length == 0) {
         return;
       }
 
       //it seems counter-intuitive to check the manifest size if someone has intentionally changed the manifest
       if(!result.sizeOk && !(/[.]txt/i.test(result.name))){
-        item = "The file size is incorrect for " + result.name;
+        item = 'The file size is incorrect for ' + result.name;
         if(item.length > 75) 
         {
-            item = item.substring(0, 75) + " ...";
+            item = item.substring(0, 75) + ' ...';
         }
 
         data.push(item);
       } else if (!result.exists) {
-        item = "Cannot find " + result.name;
+        item = 'Cannot find ' + result.name;
         if(item.length > 75) 
         {
-            item = item.substring(0, 75) + " ...";
+            item = item.substring(0, 75) + ' ...';
         }
 
         data.push(item);
@@ -81,7 +90,7 @@ SmbBrowser.prototype.files = function files(branch, next) {
     });
     
     if(!data.length){
-      data.push("OK");
+      data.push('OK');
     }
 
     return deferred.resolve(data);
@@ -199,7 +208,7 @@ SmbBrowser.readManifestFile = function readManifestFile(contents) {
     var cleaned = row.replace(/['"]+/g, '').replace(/['\r']+/g, ''),
       splitEntry = cleaned.split(':');
 
-    var version = splitEntry[2] || "99.99.99.99"
+    var version = splitEntry[2] || '99.99.99.99';
 
     var obj = { name: splitEntry[0], size: splitEntry[1], version: version};
     return obj;

--- a/src/server/services/env-service.js
+++ b/src/server/services/env-service.js
@@ -90,7 +90,7 @@ exports.version = function version(envId, next) {
              
               if(matchingRole.length > 0) {
                 if(!serviceip)  serviceip = machine.intIP;
-                return callback(null, serviceip)
+                return callback(null, serviceip);
               } else {
                 return callback(null, null);
               }
@@ -111,7 +111,7 @@ exports.version = function version(envId, next) {
               });
             }
             return {
-              version: version || "0.0.0.0"
+              version: version || '0.0.0.0'
             };
           }).fail(function(err) {
             
@@ -119,7 +119,7 @@ exports.version = function version(envId, next) {
           .nodeify(next);
       });
     });
-}
+};
 
 exports.create = function create(data, next) {
   var env = new Env(data);

--- a/src/server/services/env-service.js
+++ b/src/server/services/env-service.js
@@ -10,6 +10,11 @@ var debug           = require('debug')('deployer-envservice')
   , skytap          = Skytap.init(config.skytap)
   , envMapper       = new EnvMapper(dbPath)
   , machineMapper   = new MachineMapper(dbPath)
+  , RingtailClient  = require('ringtail-deploy-client')
+  , ConfigMapper    = require('../mappers/config-mapper')
+  , configMapper    = new ConfigMapper(dbPath)  
+  , _               = require('underscore')
+  , async           = require('async')
   , findById
   ;
 
@@ -66,6 +71,53 @@ exports.findById = findById = function get(envId, next) {
     .then(joinEnvSkytap)
     .nodeify(next);
 };
+
+exports.version = function version(envId, next) {
+  var serviceip;
+
+  machineMapper
+    .findByEnv(envId)
+    .then(function(machines) {
+      async.eachSeries(machines, function(machine, callback){
+        configMapper
+            .findById(machine.configId)
+            .then(function(conf){
+              var roles = conf.roles;
+              var possibleRoles = ['SKYTAP-ALLINONE', 'WEBAGENT', 'DEV-FULL', 'WEB', 'SKYTAP-WEB'];
+              var matchingRole = _.intersection(roles, possibleRoles);
+             
+              if(matchingRole.length > 0) {
+                if(!serviceip)  serviceip = machine.intIP;
+                return callback(null, serviceip)
+              } else {
+                return callback(null, null);
+              }
+          });
+      }, function done(){
+        var client = new RingtailClient({ serviceHost: serviceip });
+        var version;
+
+        client
+          .installed()
+          .then(function(result){
+            if(result && result.length > 0) {
+              result.forEach(function(row){
+                var versionMatches = row.match(/Ringtail Version: ([0-9\.].*)/i);
+                if(versionMatches && !version) {
+                  version = versionMatches[1];
+                }
+              });
+            }
+            return {
+              version: version || "0.0.0.0"
+            };
+          }).fail(function(err) {
+            
+          })
+          .nodeify(next);
+      });
+    });
+}
 
 exports.create = function create(data, next) {
   var env = new Env(data);

--- a/test/server/fixtures/smb-browser/branch1/20150401.1/manifest.txt
+++ b/test/server/fixtures/smb-browser/branch1/20150401.1/manifest.txt
@@ -1,0 +1,2 @@
+"Name":"Size":"Version"
+"file1.txt":"123456789":"1.0"

--- a/test/server/fixtures/smb-browser/branch1/20150401.2/manifest.txt
+++ b/test/server/fixtures/smb-browser/branch1/20150401.2/manifest.txt
@@ -1,0 +1,2 @@
+"Name":"Size":"Version"
+"file1.txt":"123456789":"1.0"

--- a/test/server/fixtures/smb-browser/branch2/manifest.txt
+++ b/test/server/fixtures/smb-browser/branch2/manifest.txt
@@ -1,0 +1,2 @@
+"Name":"Size":"Version"
+"file1.txt":"123456789":"1.0"

--- a/test/server/services/browsers/smb-browser.js
+++ b/test/server/services/browsers/smb-browser.js
@@ -61,9 +61,10 @@ describe('SmbBrowser', function() {
       var sut = new SmbBrowser(config);
       sut.builds('branch1', function(err, result) {
         expect(result).to.be.instanceOf(Array);
-        expect(result.length).to.equal(2);
+        expect(result.length).to.equal(3);
         expect(result[0]).to.equal('20150401.1');
         expect(result[1]).to.equal('20150401.2');
+        expect(result[2]).to.equal('20150401.3');
         done();
       });      
     });
@@ -72,9 +73,10 @@ describe('SmbBrowser', function() {
       sut.builds('branch1')
         .then(function(result) {
           expect(result).to.be.instanceOf(Array);
-          expect(result.length).to.equal(2);
+          expect(result.length).to.equal(3);
           expect(result[0]).to.equal('20150401.1');
           expect(result[1]).to.equal('20150401.2');
+          expect(result[2]).to.equal('20150401.3');        
           done();
         })
         .done();
@@ -87,7 +89,7 @@ describe('SmbBrowser', function() {
       sut.files('branch1/20150401.1', function(err, result) {
         expect(result).to.be.instanceOf(Array);
         expect(result.length).to.equal(1);
-        expect(result[0]).to.equal('file1.txt');
+        expect(result[0]).to.equal('OK');
         done();
       });
     });
@@ -97,7 +99,7 @@ describe('SmbBrowser', function() {
         .then(function(result) {
           expect(result).to.be.instanceOf(Array);
           expect(result.length).to.equal(1);
-          expect(result[0]).to.equal('file1.txt');
+          expect(result[0]).to.equal('OK');
           done();
         })
         .done();
@@ -110,7 +112,7 @@ describe('SmbBrowser', function() {
       sut.files('branch2', function(err, result) {
         expect(result).to.be.instanceOf(Array);
         expect(result.length).to.equal(1);
-        expect(result[0]).to.equal('file1.txt');
+        expect(result[0]).to.equal('OK');
         done();
       });
     });
@@ -120,10 +122,22 @@ describe('SmbBrowser', function() {
         .then(function(result) {
           expect(result).to.be.instanceOf(Array);
           expect(result.length).to.equal(1);
-          expect(result[0]).to.equal('file1.txt');
+          expect(result[0]).to.equal('OK');
           done();
         })
         .done();
+    });
+  });
+
+  describe('.files', function() {
+    it('should error from missing manifest', function(done) {
+      var sut = new SmbBrowser(config);
+      sut.files('branch1/20150401.3', function(err, result) {
+        expect(result).to.be.instanceOf(Array);
+        expect(result.length).to.equal(1);
+        expect(result[0]).to.equal('manifest.txt is missing');
+        done();
+      });
     });
   });
 


### PR DESCRIPTION
- Gets the ringtail version from the webserver through the deploy service
- Should not notify you if you could not get a version number
- Ignores manifest matching if server offline / version number could not be acquired
- if you get a version number it should appear above where you select a new build
![image](https://cloud.githubusercontent.com/assets/4030607/16964464/806c9696-4dc9-11e6-8336-55e559886d5d.png)
- compares manifest version number to installed version number
- implimented version / file size checking on smb
- doesn't check file size on .txt files
- message displays if no manifest exist
- requested urls show in the console with the exception of assets
