### PR TITLE
272815 config validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ build
 
 src/client/assets/css/*.css
 .vscode
+.vs/*

--- a/src/client/app/environments/editor/dialog.factory.js
+++ b/src/client/app/environments/editor/dialog.factory.js
@@ -28,9 +28,9 @@
     }
   }
 
-  EnvironmentEditorController.$inject = [ '$modalInstance', '$routeParams', 'Environment', 'environment', 'Wizard', 'Region', 'Config', '$scope' ];
+  EnvironmentEditorController.$inject = [ '$modalInstance', '$routeParams', 'Environment', 'environment', 'Wizard', 'Region', 'Config', '$scope', 'validationMessage' ];
 
-  function EnvironmentEditorController($modalInstance, $routeParams, Environment, environment, Wizard, Region, Config, $scope) {
+  function EnvironmentEditorController($modalInstance, $routeParams, Environment, environment, Wizard, Region, Config, $scope, validationMessage) {
     var vm          = this;
     vm.environment  = null;
     vm.configs      = [];
@@ -40,6 +40,7 @@
 
     activate();
 
+    
     //////////
 
     function activate() {
@@ -54,6 +55,7 @@
         create().then(configs);
       }
       vm.wizard = new Wizard(mode);
+      vm.wizard.error = null;
     }
 
     function cancel() {
@@ -72,15 +74,47 @@
         });
     }
 
-    function update() {
+    function update(skipValidation = false) {
+      validationMessage.clearMessage();
       if(environment) {
         angular.copy(vm.environment, environment);
+        if(!skipValidation && validateConfigs(environment).length > 0){
+          return;
+        }
       }
       return vm.environment
         .$update()
         .then(function(environment){
           $modalInstance.close(environment);
         });
+    }
+
+    function validateConfigs(environment){
+      var inValidMachines = [],
+      postErrorMessage = false,
+      errorMessage = 'The listed machine does not have its config set';
+
+      environment.machines.forEach(function(machineDetail) {
+          if(machineDetail.configId == null){
+            inValidMachines.push(machineDetail);
+            postErrorMessage = true;
+          }
+        }, this);
+
+        if(postErrorMessage === true){
+          if(inValidMachines.length > 1){
+            errorMessage = 'The listed machines do not have their config set';
+          }
+
+          var dataDetails = {
+            invalidmachines: inValidMachines,
+            message: errorMessage,
+            stage: 'machines'
+          };
+          validationMessage.setMessage(dataDetails.stage, dataDetails.message, dataDetails.invalidmachines);
+        }
+
+        return inValidMachines;
     }
 
     function configs() {

--- a/src/client/app/environments/editor/dialog.factory.js
+++ b/src/client/app/environments/editor/dialog.factory.js
@@ -28,9 +28,9 @@
     }
   }
 
-  EnvironmentEditorController.$inject = [ '$modalInstance', '$routeParams', 'Environment', 'environment', 'Wizard', 'Region', 'Config', '$scope', 'validationMessage' ];
+  EnvironmentEditorController.$inject = [ '$modalInstance', '$routeParams', 'Environment', 'environment', 'Wizard', 'Region', 'Config', '$scope', 'ValidationMessage' ];
 
-  function EnvironmentEditorController($modalInstance, $routeParams, Environment, environment, Wizard, Region, Config, $scope, validationMessage) {
+  function EnvironmentEditorController($modalInstance, $routeParams, Environment, environment, Wizard, Region, Config, $scope, ValidationMessage) {
     var vm          = this;
     vm.environment  = null;
     vm.configs      = [];
@@ -75,7 +75,7 @@
     }
 
     function update(skipValidation = false) {
-      validationMessage.clearMessage();
+      ValidationMessage.clearMessage();
       if(environment) {
         angular.copy(vm.environment, environment);
         if(!skipValidation && validateConfigs(environment).length > 0){
@@ -111,7 +111,7 @@
             message: errorMessage,
             stage: 'machines'
           };
-          validationMessage.setMessage(dataDetails.stage, dataDetails.message, dataDetails.invalidmachines);
+          ValidationMessage.setMessage(dataDetails.stage, dataDetails.message, dataDetails.invalidmachines);
         }
 
         return inValidMachines;

--- a/src/client/app/environments/editor/dialog.html
+++ b/src/client/app/environments/editor/dialog.html
@@ -9,8 +9,9 @@
       <ul class="nav nav-tabs">
         <li role="presentation" ng-click="vm.wizard.show('info')" ng-class="{ active: vm.wizard.stage === 'info' }"><a>Information</a></li>
         <li role="presentation" ng-click="vm.wizard.show('configs')" ng-class="{ active: vm.wizard.stage === 'configs' }"><a>Configs</a></li>
-        <li role="presentation" ng-click="vm.wizard.show('machines')" ng-class="{ active: vm.wizard.stage === 'machines' }"><a>Machines</a></li>
-        <li role="presentation" ng-click="vm.wizard.show('taskdefs')"ng-class="{ active: vm.wizard.stage === 'taskdefs' }"><a>Process</a></li>
+        <li role="presentation" ng-click="vm.wizard.show('machines')" ng-class="{ active: vm.wizard.stage === 'machines' }" ><a><i style="margin-right: 0.5em; color: #a94442;" ng-class="{ 'glyphicon glyphicon-exclamation-sign': vm.wizard.error === 'machines' }"></i>Machines</a></li>
+        <li role="presentation" ng-click="vm.wizard.show('taskdefs')" ng-class="{ active: vm.wizard.stage === 'taskdefs' }"><a>Process</a></li>
+        <li role="presentation" ng-click="vm.wizard.show('validation')" ng-class="{ active: vm.wizard.stage === 'validation' }"><a>Validation</a></li>
       </ul>
     </div>
   </div>
@@ -70,3 +71,12 @@
   >
 </envwizard-taskdefs>
 
+<envwizard-validation
+  ng-show="vm.wizard.stage === 'validation'"
+  environment="vm.environment"
+  configs="vm.configs"
+  wizard="vm.wizard"
+  cancel="vm.cancel"
+  update="vm.update"
+  >
+</envwizard-validation>

--- a/src/client/app/environments/editor/s7-validation.directive.js
+++ b/src/client/app/environments/editor/s7-validation.directive.js
@@ -22,8 +22,8 @@
     };
   }
 
-  ValidationController.$inject = ['validationMessage', '$scope'];
-  function ValidationController( validationMessage, $scope){
+  ValidationController.$inject = ['ValidationMessage', '$scope'];
+  function ValidationController( ValidationMessage, $scope){
     var vm            = this;
     vm.next           = next;
     vm.environment    = this.environment;
@@ -39,7 +39,7 @@
 
     function activate() {
       
-      validationMessage.observeMessage().then(null, null, function(message){
+      ValidationMessage.observeMessage().then(null, null, function(message){
         vm.wizard.stage = 'validation';
 
         vm.errorMessage = message.errorMessage;

--- a/src/client/app/environments/editor/s7-validation.directive.js
+++ b/src/client/app/environments/editor/s7-validation.directive.js
@@ -1,0 +1,70 @@
+(function() {
+  'use strict';
+
+  angular
+    .module('app.environments.editor')
+    .directive('envwizardValidation', envwizardValidation);
+
+  function envwizardValidation() {
+    return {
+      restrict: 'E',
+      scope: {
+        cancel: '=',
+        environment: '=',
+        configs: '=',
+        update: '=',
+        wizard: '='
+      },
+      templateUrl: '/app/environments/editor/s7-validation.html',
+      controller: ValidationController,
+      controllerAs: 'vm',
+      bindToController: true
+    };
+  }
+
+  ValidationController.$inject = ['validationMessage', '$scope'];
+  function ValidationController( validationMessage, $scope){
+    var vm            = this;
+    vm.next           = next;
+    vm.environment    = this.environment;
+    vm.configs        = this.configs;
+    vm.errorMessage   = 'Extended environment validation errors will be displayed here upon update.';
+    vm.showDetails    = false;
+    vm.errorStage     = null;
+    vm.errorDetails   = null;
+    vm.goToStage      = goToStage;
+    activate();
+
+    //////////
+
+    function activate() {
+      
+      validationMessage.observeMessage().then(null, null, function(message){
+        vm.wizard.stage = 'validation';
+
+        vm.errorMessage = message.errorMessage;
+        vm.errorStage = message.errorStage;
+        vm.errorDetails = message.errorDetails;
+        vm.wizard.error = message.errorStage;
+        if(message.errorStage){
+          vm.showDetails = true;
+        }else{
+          vm.showDetails = false;
+        }
+
+      });
+    }
+    
+    function next() {
+      vm.wizard.stage = 'taskdefs';
+    }
+
+    function prev() {
+      vm.wizard.stage = 'info';
+    }
+    
+    function goToStage() {
+      vm.wizard.stage = vm.errorStage;
+    }
+  }
+}());

--- a/src/client/app/environments/editor/s7-validation.html
+++ b/src/client/app/environments/editor/s7-validation.html
@@ -1,0 +1,20 @@
+
+<div class="model-body pad-left pad-right pad-top">
+  <div class="row">
+    <div class="col-sm-12">
+      <div style="margin-bottom: 2em;">Extended environment validation errors will be displayed here upon update.</div>
+      <span ng-if="vm.errorStage === 'machines'">
+        <ul class="list-group">
+          <li class="list-group-item list-group-item-warning"><strong>Warning!:</strong> {{vm.errorMessage}}, hit update to continue or navigate to the {{vm.errorStage}} tab to address the issue.</li>
+          <li style="margin-left:20px;" class="list-group-item" ng-repeat="machine in vm.errorDetails"><a href="" class="alert-link" ng-click="vm.goToStage()">{{machine.machineName}}</a></li>
+        </ul>
+          <div style="margin-top: 1em;">
+      </span>
+    </div>
+  </div>
+</div>
+
+<div class="modal-footer">
+  <button type="button" class="btn btn-primary" ng-click="vm.update(true)">Update</button>
+  <button type="button" class="btn btn-warning" ng-click="vm.cancel()">Cancel</button>
+</div>

--- a/src/client/app/environments/editor/validation-message.service.js
+++ b/src/client/app/environments/editor/validation-message.service.js
@@ -1,0 +1,34 @@
+(function() {
+  'use strict';
+
+  angular
+    .module('app.environments.editor')
+    .service('validationMessage', function($q){
+      var self = this,
+      defer = $q.defer();
+      this.message = null;
+      
+      this.observeMessage = function() {
+        return defer.promise;
+      };
+      
+      this.setMessage = function(wizardStage, errorMessage, details ) {
+        self.message = {
+          errorStage: wizardStage,
+          errorMessage: errorMessage,
+          errorDetails: details
+        };
+        defer.notify(self.message);
+      };
+
+      this.clearMessage = function( ) {
+        self.message = {
+          errorStage: '',
+          errorMessage: '',
+          errorDetails: ''
+        };
+        defer.notify(self.message);
+      };
+    });
+    
+}());

--- a/src/client/app/environments/editor/validation-message.service.js
+++ b/src/client/app/environments/editor/validation-message.service.js
@@ -3,7 +3,7 @@
 
   angular
     .module('app.environments.editor')
-    .service('validationMessage', function($q){
+    .service('ValidationMessage', function($q){
       var self = this,
       defer = $q.defer();
       this.message = null;

--- a/src/client/app/environments/machine/details.directive.js
+++ b/src/client/app/environments/machine/details.directive.js
@@ -20,9 +20,9 @@
     };
   }
 
-  Controller.$inject = [ '$scope' ];
+  Controller.$inject = [ '$scope','validationMessage' ];
 
-  function Controller($scope) {
+  function Controller($scope, validationMessage) {
     var vm         = this;
     vm.configs     = this.configs;
     vm.machine     = this.machine;
@@ -30,6 +30,7 @@
     vm.config      = null;
     vm.configName  = null;
     vm.configIndex = null;
+    vm.hasError    = false;
 
     activate();
 
@@ -38,6 +39,19 @@
     function activate() {
       $scope.$parent.$watch('vm.configs', configsChanged, true);
       $scope.$watch('vm.machine', machineChanged, true);
+      validationMessage.observeMessage().then(null, null, function(message){
+        handleMachineConfigError(message);
+      });
+    }
+
+    function handleMachineConfigError(message){
+      if(message.errorStage && message.errorStage === 'machines'){
+        message.errorDetails.forEach(function(error) {
+          if(error.machineId === vm.machine.machineId){
+            vm.hasError = true;
+          }
+        });
+      }
     }
 
     function configsChanged(configs) {

--- a/src/client/app/environments/machine/details.directive.js
+++ b/src/client/app/environments/machine/details.directive.js
@@ -20,9 +20,9 @@
     };
   }
 
-  Controller.$inject = [ '$scope','validationMessage' ];
+  Controller.$inject = [ '$scope','ValidationMessage' ];
 
-  function Controller($scope, validationMessage) {
+  function Controller($scope, ValidationMessage) {
     var vm         = this;
     vm.configs     = this.configs;
     vm.machine     = this.machine;
@@ -39,7 +39,7 @@
     function activate() {
       $scope.$parent.$watch('vm.configs', configsChanged, true);
       $scope.$watch('vm.machine', machineChanged, true);
-      validationMessage.observeMessage().then(null, null, function(message){
+      ValidationMessage.observeMessage().then(null, null, function(message){
         handleMachineConfigError(message);
       });
     }

--- a/src/client/app/environments/machine/details.html
+++ b/src/client/app/environments/machine/details.html
@@ -1,7 +1,7 @@
 
 <div class="machine-details" ng-class="{editable: vm.editable}">
   <div class="machine-config config-{{vm.configIndex}}">
-    <h4 class="machine-name">{{ vm.machine.machineName }}</h4>
+    <h4 class="machine-name"><i style="margin-right: 0.5em; color: #a94442;" ng-class="{ 'glyphicon-machine glyphicon glyphicon-exclamation-sign': vm.hasError === true }"></i>{{ vm.machine.machineName }}</h4>
     <span class="machine-ip">{{ vm.machine.intIP }}</span>
   </div>
 </div>

--- a/src/client/assets/css/app.styl
+++ b/src/client/assets/css/app.styl
@@ -7,6 +7,9 @@ $good-green-color = #2ECC40;
 * {
   border-radius: 0 !important;
 }
+.glyphicon-machine{
+  font-size: 15px;
+}
 
 .environment-status {
   text-align: right;

--- a/src/client/index.html
+++ b/src/client/index.html
@@ -51,7 +51,9 @@
   <script type="text/javascript" src="/app/environments/editor/s4-machines.directive.js"></script>
   <script type="text/javascript" src="/app/environments/editor/s5-taskdefs.directive.js"></script>
   <script type="text/javascript" src="/app/environments/editor/s6-skytap.directive.js"></script>
+  <script type="text/javascript" src="/app/environments/editor/s7-validation.directive.js"></script>
   <script type="text/javascript" src="/app/environments/editor/wizard.factory.js"></script>
+  <script type="text/javascript" src="/app/environments/editor/validation-message.service.js"></script>
 
   <script type="text/javascript" src="/app/environments/machine/_module.js"></script>
   <script type="text/javascript" src="/app/environments/machine/details.directive.js"></script>


### PR DESCRIPTION
Adds a new tab into the environment wizard, "Validation".  The new tab will be used to display extended validation warnings and errors.  The initial validation checks the machines for a config.  If there is a missing config, a warning is displayed on the Validation tab allowing the user to either correct or ignore ( the ignore is necessary at this time because certain machines such as a load balancer will not have a config).  In the warning state, it is only possible to update and ignore the warning from the validation tab.  The long term plan will be to give all machines a valid configuration ( for instance, a dummy configuration for balancers ).