### PR TITLE
Cleanup on the job details screen.

### DIFF
--- a/src/client/app/jobs/task-details.directive.html
+++ b/src/client/app/jobs/task-details.directive.html
@@ -8,22 +8,9 @@
     </tab-heading>
     <p></p>     
 
-    <div class="panel panel-default" ng-show="tab.task.runlog">
-      <div class="panel-heading">Most Recent Run Log</div>
-      <ul class="list-group">
-        <li class="list-group-item lastlog" ng-repeat="entry in tab.task.runlog" ng-if="$last" >
-          <strong>{{entry.date | date:'mediumTime' }}:</strong> <span ng-bind-html="entry.data | trust"></span>
-        </li>
-      </ul>
-    </div>   
-
     <div class="panel panel-default" ng-show="tab.task.runlogArray">
       <div class="panel-heading">Most Recent Run Detail</div>
-      <ul class="list-group">
-        <li class="list-group-item lastlog" ng-repeat="entry in tab.task.runlogArray" ng-if="$last" ng-bind-html="entry | trust">
-          {{entry}}
-        </li>
-      </ul>
+      <div class="panel-body task-rundetails" ng-repeat="entry in tab.task.runlogArray" ng-if="$last" ng-bind-html="entry | nbsp | trust"></div>
     </div>  
 
     <div class="panel panel-default">


### PR DESCRIPTION
The most recent Run Log didn't really add much value, since that part of
the log is usually pretty trim.
The most recent run detail was stripping out spaces, which made the
DataCamel look like junk.