### PR TITLE
allow proxies to be set through docker run and remove default skytap options

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -81,20 +81,14 @@ RUN mkdir data
 
 #SETUP CONFIG
 RUN cp config.js.example config.js
-RUN if [ -z ${PROXY_URL+x} ]; then echo "####NO PROXY URL SET####" \
-	&& sed -i "s/'SKYTAP_TOKEN',/'SKYTAP_TOKEN'/g" config.js \
-	&& sed -i "s/proxy.*[']//g" config.js; \
-else \
-	sed -i "s,OPTIONAL_PROXY_SETTING,$PROXY_URL,g" config.js \
-	&& echo "----SKYTAP PROXY SET----"; \
-fi
 
-RUN sed -i "s,SKYTAP_USERNAME,$SKYTAP_USER,g" config.js \
-	&& sed -i "s,SKYTAP_TOKEN,$SKYTAP_TOKEN,g" config.js \
-	&& npm install --only=production \
+RUN npm install --only=production \
 	&& bower install --allow-root \
 	&& touch start.sh && chmod +x start.sh \
 	&& echo "DEBUG=deployer* npm start" >> start.sh
+
+ENV http_proxy=""
+ENV https_proxy=""
 
 #EXPOSE PORTS
 EXPOSE 8080 5858

--- a/src/server/controllers/skytap.js
+++ b/src/server/controllers/skytap.js
@@ -9,6 +9,8 @@ if(process.env.skytapUser && process.env.skytapToken) {
 
   if(process.env.skytapProxy) {
     config.skytap.proxy = process.env.skytapProxy;
+  } else {
+    config.skytap.proxy = '';
   }
 }
 

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -24,6 +24,16 @@ let app  = express();
 let key, cert;
 let hour = 3600000;
 
+// SET ENVIRONMENT VARIABLES
+if(process.env.proxy) {
+  let proxyVal = process.env.proxy;
+  if(proxyVal == 'none') proxyVal = '';
+
+  process.env['http_proxy'] = proxyVal; 
+  process.env['https_proxy'] = proxyVal; 
+  process.env['HTTP_PROXY'] = proxyVal;
+  process.env['HTTPS_PROXY'] = proxyVal;
+}
 
 //JWT CERTS
 try {


### PR DESCRIPTION
don't make image with predefined tokens
remove proxy that was used to create image
allow proxy to be overwritten by docker run environment
