### PR TITLE
sorting and updated view

### DIFF
--- a/src/client/app/environments/redeploy/dialog.directive.js
+++ b/src/client/app/environments/redeploy/dialog.directive.js
@@ -416,7 +416,7 @@
         'hideCheck': false,
         'selectable' : true,
         'isSelected': rootItemChecked,
-        'children': [],
+        'children': []
       };
       
       listOfKeys.forEach(function(keyItemDetail) {

--- a/src/client/app/jobs/task-details.directive.html
+++ b/src/client/app/jobs/task-details.directive.html
@@ -27,5 +27,12 @@
       <div class="panel-body task-rundetails" ng-bind-html="tab.task.rundetails | nbsp | trust">
       </div>
     </div>
+
+    <div class="panel panel-default" ng-show="tab.newLaunchKeys.length && vm.showLaunchKeys">
+      <div class="panel-heading">New Launch Keys</div>
+      <div ng-repeat="key in tab.newLaunchKeys | orderBy:'FeatureKey'" class="panel-launch-keys">
+          <strong>{{key.FeatureKey}}:</strong> {{key.Description}}
+      </div>    
+    </div>
   </tab>      
 </tabset>

--- a/src/client/app/jobs/task-details.directive.js
+++ b/src/client/app/jobs/task-details.directive.js
@@ -10,7 +10,7 @@
     return { 
       restrict: 'E',
       scope: {
-        task: '=',
+        task: '='
       },
       templateUrl: '/app/jobs/task-details.directive.html',
       controller: 'TaskDetailsController',

--- a/src/client/app/jobs/task-details.directive.js
+++ b/src/client/app/jobs/task-details.directive.js
@@ -10,7 +10,7 @@
     return { 
       restrict: 'E',
       scope: {
-        task: '='
+        task: '=',
       },
       templateUrl: '/app/jobs/task-details.directive.html',
       controller: 'TaskDetailsController',
@@ -25,25 +25,38 @@
     vm.selectedTab  = 0;
     vm.tabs         = [];
     vm.selectTab    = selectTab;
+    vm.showLaunchKeys = true;
+    vm.newLaunchKeys = [];
     
     activate();
     
     //////////
     
     function activate() {
+      $scope.$parent.$watch('vm.job.env', onEnvUpdate);      
       $scope.$parent.$watch('vm.currentTask', onTaskUpdate);
     }
 
+    function onEnvUpdate(rootEnv) {
+      if(rootEnv && rootEnv.newLaunchKeys) {
+        vm.newLaunchKeys = rootEnv.newLaunchKeys;
+      }
+    }
 
     function onTaskUpdate(rootTask) {
       if(rootTask) {        
         vm.tabs = [];
+      
+        if(rootTask && rootTask.taskdefs && rootTask.taskdefs[0] && rootTask.taskdefs[0].task != "3-install-machine") {
+          vm.showLaunchKeys = false; 
+        }
 
         vm.tabs.push({
           title: rootTask.name,
           task: rootTask,
           active: vm.selectedTab === 0,
-          disabled: false
+          disabled: false,
+          newLaunchKeys: vm.newLaunchKeys
         });
 
         if(rootTask.tasks) {

--- a/src/client/assets/css/app.styl
+++ b/src/client/assets/css/app.styl
@@ -321,6 +321,12 @@ env-redeploy {
   }
 }
 
+.panel-launch-keys {
+  padding-left: 10px;
+  padding-right: 10px;
+  line-height: 25px;
+}
+
 .skytap-selectlist {
   min-height: 220px;
   

--- a/src/server/controllers/envs.js
+++ b/src/server/controllers/envs.js
@@ -98,18 +98,19 @@ exports.pause = function pause(req, res, next) {
 };
 
 
-exports.redeploy = function redeploy(req, res, next) {
+exports.redeploy = async function redeploy(req, res, next) {
   debug('redeploy');
   var data = req.body
     , opts = parseQueryString(req.query)
     ;
-
-  redeployService
-    .redeploy(data, opts, function(err, result) {
-      res.result = result;
-      res.err = err;
-      next();
-    });
+  
+  try {
+    res.result = await redeployService.redeploy(data, opts);
+  } catch(err) {
+    res.err = err;
+  }
+  
+  return next();
 };
 
 exports.quickdeploy = async function quickdeploy(req, res, next) {

--- a/src/server/mappers/env.sql
+++ b/src/server/mappers/env.sql
@@ -1,19 +1,22 @@
 -- insert
 insert into env (
   envId, envName, envDesc, status, remoteType, remoteId, config,
-  deployedBy, deployedOn, deployedUntil, deployedNotes, deployedBranch, deployedJobId, host, updatePath
+  deployedBy, deployedOn, deployedUntil, deployedNotes, deployedBranch, 
+  deployedJobId, host, updatePath
 )
 values (
   $envId, $envName, $envDesc, $status, $remoteType, $remoteId, $config,
-  $deployedBy, $deployedOn, $deployedUntil, $deployedNotes, $deployedBranch, $deployedJobId, $host, $updatePath
+  $deployedBy, $deployedOn, $deployedUntil, $deployedNotes, $deployedBranch, 
+  $deployedJobId, $host, $updatePath
 );
 
 
 -- update
 update env
 set
-  envName = $envName, envDesc = $envDesc, status = $status, remoteType = $remoteType, remoteId = $remoteId, config = $config,
-  deployedBy = $deployedBy, deployedOn = $deployedOn, deployedUntil = $deployedUntil, deployedNotes = $deployedNotes, deployedBranch = $deployedBranch, deployedJobId = $deployedJobId,
+  envName = $envName, envDesc = $envDesc, status = $status, remoteType = $remoteType, remoteId = $remoteId, 
+  config = $config, deployedBy = $deployedBy, deployedOn = $deployedOn, deployedUntil = $deployedUntil, 
+  deployedNotes = $deployedNotes, deployedBranch = $deployedBranch, deployedJobId = $deployedJobId,
   host = $host, updatePath = $updatePath
 
 where envId = $envId;

--- a/src/server/models/env.js
+++ b/src/server/models/env.js
@@ -24,7 +24,8 @@ schema = {
     { "name": "deployedJobId" },
     { "name": "runstate" },
     { "name": "machines" },
-    { "name": "updatePath" }
+    { "name": "updatePath" },
+    { "name": "newLaunchKeys" }
   ]
 };
 /* eslint-enable */

--- a/src/server/services/launchkey-service.js
+++ b/src/server/services/launchkey-service.js
@@ -39,9 +39,13 @@ exports.requestLaunchKeys = function requestLaunchKeys(data, next) {
           client = me.serviceClient = new RingtailClient({ serviceHost: serviceIP });
         })
         .then(function(result) {
-          client
-            .getLaunchKeys(branch)
-            .nodeify(next);
+          try {
+            client
+              .getLaunchKeys(branch)
+              .nodeify(next);
+          } catch(e) {
+            console.error("requestLaunchKeys: no launch keys");
+          }
         });
     });
 };


### PR DESCRIPTION
- no ring should not display launch key selector
- development ring should display launch key selector
- deployment rings other than development should not show the launch key selector, but should select all the values behind the scenes for it's tier and above

- on the job page there should be a new section under the first tab of the 3-install-many tab that shows only the newly selected launch keys, in alphabetical order.