### PR TITLE
Env bar was showing orange when it should be green.

### DIFF
--- a/src/client/app/environments/redeploy/dialog.html
+++ b/src/client/app/environments/redeploy/dialog.html
@@ -19,7 +19,7 @@
       </select>
     </div>
     <div class="form-group">
-      <label>Install Build: <span ng-show='vm.version'>(Current: {{vm.version}})</span></label>
+      <label>Install Build: <span ng-show='vm.version'>({{vm.version}} is currently installed.)</span></label>
       <div class="list-loading" ng-show="vm.loadingBuilds">
         <img src="/assets/img/bar-loader.gif">
       </div>

--- a/src/client/assets/css/app.styl
+++ b/src/client/assets/css/app.styl
@@ -302,9 +302,9 @@ env-redeploy {
       &.status-running, &.status-deployed {
         background-color: rgba(92,184,92,.8);
       }
-      &.status-running, &.status-warning {
+      &.status-warning {
         background-color: #f0ad4e;
-      }      
+      }
       &.status-suspended {
         background-color: #e0e0e0;
       }


### PR DESCRIPTION
Fixes a bug with the env bar showing as orange when it should be green.
Changes the wording on the installed build because the old wording was
confusing people.