### PR TITLE
Show empty text when there are no new launch keys

### DIFF
--- a/src/client/app/jobs/task-details.directive.html
+++ b/src/client/app/jobs/task-details.directive.html
@@ -28,8 +28,9 @@
       </div>
     </div>
 
-    <div class="panel panel-default" ng-show="tab.newLaunchKeys.length && vm.showLaunchKeys">
+    <div class="panel panel-default" ng-show="vm.showLaunchKeys">
       <div class="panel-heading">New Launch Keys</div>
+      <div class="panel-launch-keys" ng-show="!tab.newLaunchKeys.length">This environment already has all the keys it needs.</div>
       <div ng-repeat="key in tab.newLaunchKeys | orderBy:'FeatureKey'" class="panel-launch-keys">
           <strong>{{key.FeatureKey}}:</strong> {{key.Description}}
       </div>


### PR DESCRIPTION
Users were feeling uneasy that there was no acknowledgement wheteher or
not keys were getting lit.  This will give them better confidence that
there are no keys.