### PR TITLE
Set the update target during installation.

### DIFF
--- a/src/server/tasks/3-install-machine.js
+++ b/src/server/tasks/3-install-machine.js
@@ -50,6 +50,13 @@ function TaskImpl(options) {
     log('waiting until the service is responsive ' + client.statusUrl);
     await client.waitForService();
 
+    if(this.region && this.region.serviceConfig && this.region.serviceConfig.updatePath) {
+      // point the installer service to the desired regional path.
+      let path = this.region.serviceConfig.updatePath;
+      log('setting the install update location to ' + path);
+      await client.setUpdatePath(path);
+    }
+
     // upgrade install service
     log('updating install service to latest version');
     await client.update();

--- a/test/server/tasks/3-install-many.js
+++ b/test/server/tasks/3-install-many.js
@@ -17,6 +17,7 @@ describe('3-install-many', function() {
       , log
       , scope
       , env
+      , region
       ;
 
     beforeEach(function() {
@@ -34,10 +35,10 @@ describe('3-install-many', function() {
 
       EnvSvc.findRegionByEnvId = function(x) {
         return region.regionId;
-      }
+      };
       RegSvc.findById = function(x) {
         return region;
-      }
+      };
       scope = {
         'me': env
       };

--- a/test/server/tasks/3-install-many.js
+++ b/test/server/tasks/3-install-many.js
@@ -2,10 +2,12 @@ var mocha   = require('mocha')
   , sinon   = require('sinon')
   , chai    = require('chai')
   , expect  = chai.expect
-
-  , Q               = require('q')
-  , Env         = require('../../../src/server/models/env')
-  , Task        = require('../../../src/server/tasks/3-install-many')
+  , Q       = require('q')
+  , Env     = require('../../../src/server/models/env')
+  , Region  = require('../../../src/server/models/region')
+  , Task    = require('../../../src/server/tasks/3-install-many')
+  , EnvSvc  = require('../../../src/server/services/env-service')    
+  , RegSvc  = require('../../../src/server/services/region-service')  
   ;
 
 describe('3-install-many', function() {
@@ -26,6 +28,16 @@ describe('3-install-many', function() {
           { machineId: 3, configId: null, machineName: 'Machine 3' }
         ]
       });
+      region = new Region({
+        regionId: 1001
+      });      
+
+      EnvSvc.findRegionByEnvId = function(x) {
+        return region.regionId;
+      }
+      RegSvc.findById = function(x) {
+        return region;
+      }
       scope = {
         'me': env
       };
@@ -91,6 +103,16 @@ describe('3-install-many', function() {
           .then(done)
           .catch(done);
       });
+      it('includes the regionId in the taskdefs', function(done) {
+        task
+          .execute(scope, log)
+          .then(function() {
+            expect(task.taskdefs[0].options.region.regionId).to.equal(region.regionId);
+            expect(task.taskdefs[1].options.region.regionId).to.equal(region.regionId);
+          })
+          .then(done)
+          .catch(done);
+      });      
       it('includes the configId in the taskdefs', function(done) {
         task
           .execute(scope, log)


### PR DESCRIPTION
* Refactored the 3-install-many to use async await rathaer than Q.
* Fetching the region info during install.
* If the region has a config (that hasn't been built yet), for the path,
we'll call the client to set the path.