### PR TITLE
Fixes LTS environments, but breaks the LK fix.

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,4 +1,6 @@
 {
   "directory": "src/client/assets/bower_components",
-  "interactive": false
+  "interactive": false,
+  "proxy":"http://proxy.tech.local:8080",
+  "https-proxy":"http://proxy.tech.local:8080"
 }

--- a/.bowerrc
+++ b/.bowerrc
@@ -1,6 +1,4 @@
 {
   "directory": "src/client/assets/bower_components",
-  "interactive": false,
-  "proxy":"http://proxy.tech.local:8080",
-  "https-proxy":"http://proxy.tech.local:8080"
+  "interactive": false
 }

--- a/src/client/app/environments/redeploy/dialog.directive.js
+++ b/src/client/app/environments/redeploy/dialog.directive.js
@@ -89,10 +89,9 @@
           vm.region = result;
 
           var browseType = result && result.browseConfig && result.browseConfig.type || null;
-          if(browseType === 'static' || browseType === 'http') { 
-            vm.keysLoaded = true;        
-          }
-
+          //if(browseType === 'static' || browseType === 'http') {    // temporarily disabling this check as it prevents LTS environments from being upgraded, which is worse than dropping launch keys.
+            vm.keysLoaded = true;    
+          //}
         }
       });
 


### PR DESCRIPTION
LTS environments never have their start buttton become enabled.
This makes it so the LaunchKey fix is OFF, but fixes LTS environments.
This is a tempoarary fix until a better fix can be made.