### PR TITLE
Fixes a licensing bug

### DIFF
--- a/src/client/app/environments/config/ringtail-field.service.js
+++ b/src/client/app/environments/config/ringtail-field.service.js
@@ -399,8 +399,7 @@
       "key": "RINGTAILCLASSICWEBSITEMAPPING",
       "title": "Ringtail Legal Web Site Mapping",
       "description": "The web site mapping that is used for Ringtail Legal (Classic) (e.g. Classic)",
-      "default": "Classic",
-      "ignoreWhen": "Legal",
+      "default": "Classic"
     },
     {
       "key": "SELFSERVICEAUTHENTICATIONMODE",


### PR DESCRIPTION
The deployer is forcing licensing to use a Classic mapping, whereas many licenses are mapped to Legal