### PR TITLE
When the validations pass, immediately start the deployment

### DIFF
--- a/src/client/app/environments/redeploy/dialog.directive.js
+++ b/src/client/app/environments/redeploy/dialog.directive.js
@@ -252,6 +252,10 @@
         vm.message = null;
         vm.poll = null;
         vm.validationJob.started = [];
+
+        if(validationJob.status === 'Succeeded') {
+          vm.rebuild();
+        }
       }
     }    
 

--- a/src/client/app/environments/redeploy/dialog.html
+++ b/src/client/app/environments/redeploy/dialog.html
@@ -118,7 +118,7 @@
 <div class="modal-footer">  
   <a style="float: left" ng-show="vm.tempEnv.config.taskdefs.length > 1" ng-click="vm.toggleAdvanced()">Advanced</a> 
   <div class='environment-loading' ng-show="!!vm.message">{{vm.message}} <div class='loading sm inline bar'/></div>
-  <button ng-hide="!vm.hideValidations" type="button" class="btn btn-primary" ng-disabled="vm.filesInvalid || !vm.isDeployed || !vm.keysLoaded || vm.message " ng-click="vm.validate()">Validate</button>  
-  <button type="button" ng-hide="vm.hideValidations" class="btn btn-primary" ng-disabled="vm.filesInvalid || !vm.isDeployed || !vm.keysLoaded || vm.message " ng-click="vm.rebuild()">Start</button>
+  <button ng-hide="!vm.hideValidations" type="button" class="btn btn-primary" ng-disabled="vm.filesInvalid || !vm.isDeployed || !vm.keysLoaded || vm.message " ng-click="vm.validate()">Start</button>  
+  <button type="button" ng-hide="vm.hideValidations" class="btn btn-primary" ng-disabled="vm.filesInvalid || !vm.isDeployed || !vm.keysLoaded || vm.message " ng-click="vm.rebuild()">Deploy</button>
   <button type="button" class="btn btn-default" ng-click="vm.cancel()">Cancel</button>
 </div>


### PR DESCRIPTION
* When validatiosn pass the deployment job will immediately start.
* Changed the button name from 'validate' to 'start'.
* Left the 'deploy' button there in case somone needs it as a
workaround, with the intent to rip it out soon, since it's only there if
Validations fail, but for some reason you still need to kick off the
job.