### PR TITLE
Removed deprecated warnings from express

### DIFF
--- a/src/server/controllers/envs.js
+++ b/src/server/controllers/envs.js
@@ -113,8 +113,13 @@ exports.redeploy = async function redeploy(req, res, next) {
 
 exports.quickdeploy = async function quickdeploy(req, res, next) {
   var data = {};
-  data.envId = req.param('envId');
-  data.branch = req.param('branch');
+  data.envId = req.params.envId;
+  /** data.branch = req.params.branch; // doesn't work causes a bug.
+   *  Express 4 will treat this param as a string and process the '\\' as an escape character
+   *  changing the string value from 'Main\\Latest' to 'Main\Latest', which will cause an error down the road
+   */
+  data.branch = req.param('branch'); 
+  
   debug('quickdeploy - env: ' + data.envId + ' branch: %s', data.branch);
   let response = {};
   try {

--- a/src/server/controllers/envs.js
+++ b/src/server/controllers/envs.js
@@ -73,7 +73,7 @@ exports.remove = function remove(req, res, next) {
 exports.start = function start(req, res, next) {
   debug('starting environment');
   var data          = req.body
-    , suspendOnIdle = req.param('suspend_on_idle');
+    , suspendOnIdle = req.params.suspend_on_idle;
 
   envService
     .start(data, suspendOnIdle, function(err, result) {
@@ -132,7 +132,7 @@ exports.quickdeploy = async function quickdeploy(req, res, next) {
 exports.validate = async function validate(req, res, next) {
   var data = {}
     , opts = parseQueryString(req.query);
-  data.envId = req.param('envId');
+  data.envId = req.params.envId;
   data.branch = req.param('branch');
   debug('validate - env: ' + data.envId + ' branch: %s', data.branch);
   let response = {};
@@ -152,7 +152,7 @@ exports.validate = async function validate(req, res, next) {
 
 exports.reset = function reset(req, res, next) {
   debug('reset');
-  var envId = req.param('envId');
+  var envId = req.params.envId;
 
   envService
     .reset(envId, function(err, result) {

--- a/src/server/controllers/jobs.js
+++ b/src/server/controllers/jobs.js
@@ -20,7 +20,7 @@ exports.listValidations = (req, res) => {
 };
 
 exports.getValidations = (req, res) => {
-  let jobId = req.param('validationId');
+  let jobId = req.params.validationId;
   debug('getValidations ' + jobId);
   validationrunner.getValidation(jobId, (err, data) => {
     let runLogs = [];
@@ -247,7 +247,7 @@ exports.failureDetailsList = function failureDetailsList(req, res, next) {
 };
 
 exports.get = (req, res) => {
-  let jobId = req.param('jobId');
+  let jobId = req.params.jobId;
 
   jobrunner.getJob(jobId, (err, data) => {
     res.send(data);
@@ -255,7 +255,7 @@ exports.get = (req, res) => {
 };
 
 exports.downloadLog = function downloadLog(req, res) {
-  let jobId = req.param('jobId');
+  let jobId = req.params.jobId;
 
   jobrunner.getJob(jobId, function(err, data){
     let filename = 'deployer.' +jobId + '.log.txt';

--- a/src/server/controllers/regionenvs.js
+++ b/src/server/controllers/regionenvs.js
@@ -6,9 +6,9 @@ var debug           = require('debug')('deployer-regions')
 
 exports.list = function region(req, res, next) {
   debug('listing environments for region');
-  var regionId = req.param('regionId')
-    , page     = req.query.page
-    , pagesize = req.query.pagesize
+  var regionId = req.params.regionId,
+      page     = req.query.page,
+      pagesize = req.query.pagesize
     ;
   envService
     .findByRegion(regionId, { page: page, pagesize: pagesize }, function(err, result) {
@@ -20,8 +20,8 @@ exports.list = function region(req, res, next) {
 
 
 exports.add = function add(req, res, next) {
-  var regionId = req.param('regionId')
-    , envId    = req.param('envId')
+  var regionId = req.params.regionId,
+      envId    = req.params.envId
     ;
   regionService
     .addEnv(regionId, envId, function(err, result) {
@@ -33,8 +33,8 @@ exports.add = function add(req, res, next) {
 
 
 exports.remove = function remove(req, res, next) {
-  var regionId = req.param('regionId')
-    , envId    = req.param('envId')
+  var regionId = req.params.regionId,
+      envId    = req.params.envId
     ;
   regionService
     .removeEnv(regionId, envId, function(err, result) {

--- a/src/server/controllers/regions.js
+++ b/src/server/controllers/regions.js
@@ -17,7 +17,7 @@ exports.list = function list(req, res, next) {
 
 exports.get = function get(req, res, next) {
   debug('getting region');
-  var regionId = req.param('regionId');
+  var regionId = req.params.regionId;
   regionService
     .findById(regionId, function(err, result) {
       res.result  = result;
@@ -51,7 +51,7 @@ exports.update = function update(req, res, next) {
 
 exports.del = function del(req, res, next) {
   debug('deleting region');
-  var id = req.param('regionid');
+  var id = req.params.regionid;
   regionService
     .del(id, function(err, result) {
       res.result = result;

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -69,7 +69,6 @@ app.use(session({
    secret : config.cookieSecret,
    name : 'sessionId',
    resave: false,
-   //saveUninitialized: false,
    rolling: true
   })
 );

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -68,6 +68,8 @@ app.use(cookieParser(config.cookieSecret));
 app.use(session({
    secret : config.cookieSecret,
    name : 'sessionId',
+   resave: false,
+   //saveUninitialized: false,
    rolling: true
   })
 );


### PR DESCRIPTION
# Express 3 to 4 upgrade notes 

In **/src/server/server.js**: 
*` express-session deprecated undefined resave option; provide resave option`
Add the following flag 
`resave: false, `
to the app.use() section on lines 68 
[Documentation - read more](https://github.com/expressjs/session#resave)

In **/src/server/server.js**:
`* express-session deprecated undefined saveUninitialized option; provide saveUninitialized option `
Add the following flag 
`saveUninitialized: false,`
to the app.use() section on lines 68 
[Documentation - read more](https://github.com/expressjs/session#saveuninitialized)

`* express deprecated req.param(name): Use req.params, req.body, or req.query instead`
replace the following Express 3 syntax 
`req.param('fieldName')`
with 
`req.params.fieldName `

This syntax exsists throughout the appication. 

## Issues 
There appears to be an issue with req.param.branch, anytime the branch is used we must use the express 3 syntax
```
Console.log(req.param('branch'));
> Latest\\Main
```
```
Console.log(req.params.branch);
> Latest\Main
``` 
Because Express 4 treats it as a string, it treats the double backslash as an escape character which
causes errors in other parts of the application due to the escape char  