### PR TITLE
Fixed Undefined JobId field in the download logger

### DIFF
--- a/src/server/controllers/jobs.js
+++ b/src/server/controllers/jobs.js
@@ -269,7 +269,7 @@ exports.downloadLog = function downloadLog(req, res) {
         formattedlog += 'JOB ID : ' + (task.id || jobId) + '\n';
         formattedlog += 'TASK NAME: ' + task.name + '\n';
         formattedlog += 'STARTED: ' + task.started + '\n';
-        formattedlog += 'ENDED: ' + (task.stopped||task.endTime) + '\n';
+        formattedlog += 'ENDED: ' + (task.stopped||task.endTime||task.status) + '\n';
         formattedlog += 'STATUS: ' + task.status + '\n\n';
 
         if(task.taskdefs) {

--- a/src/server/controllers/jobs.js
+++ b/src/server/controllers/jobs.js
@@ -266,7 +266,7 @@ exports.downloadLog = function downloadLog(req, res) {
       content = JSON.stringify(content, null, 4);
 
       for(let task of data.tasks) {
-        formattedlog += 'JOB ID: ' + task.id + '\n';
+        formattedlog += 'JOB ID : ' + (task.id || jobId) + '\n';
         formattedlog += 'TASK NAME: ' + task.name + '\n';
         formattedlog += 'STARTED: ' + task.started + '\n';
         formattedlog += 'ENDED: ' + (task.stopped||task.endTime) + '\n';


### PR DESCRIPTION
Added a conditional for task.id, if its undefined or null, populate the field with the jobId param in the download log. 