### PR TITLE
IE Bug Fix

### DIFF
--- a/src/client/app/environments/editor/dialog.factory.js
+++ b/src/client/app/environments/editor/dialog.factory.js
@@ -77,8 +77,12 @@
           Region.addEnv({regionId:currentRegion, envId: environment.envId});
         });
     }
-
-    function update(skipValidation = false) {
+     // function update(skipValidation = false) {
+     // ES5 IE11 comp 
+     function update(skipValidation ) {
+      if( skipValidation === undefined || null) {
+        skipValidation = false; 
+      }
       ValidationMessage.clearMessage();
       if(environment) {
         angular.copy(vm.environment, environment);

--- a/src/client/app/environments/editor/dialog.factory.js
+++ b/src/client/app/environments/editor/dialog.factory.js
@@ -79,8 +79,8 @@
     }
      // function update(skipValidation = false) {
      // ES5 IE11 comp 
-     function update(skipValidation ) {
-      if( skipValidation === undefined || null) {
+     function update(skipValidation){
+      if(skipValidation === undefined || null) {
         skipValidation = false; 
       }
       ValidationMessage.clearMessage();


### PR DESCRIPTION
IE does not support ES6 standards including default parameters in functions. We can work around this by assigning the skipValidation if its null in the body of the function as opposed to in the function input.